### PR TITLE
Invariant culture for parsing decimals and doubles

### DIFF
--- a/EOSNewYork.EOSCore/Response/API/Account.cs
+++ b/EOSNewYork.EOSCore/Response/API/Account.cs
@@ -45,7 +45,7 @@ namespace EOSNewYork.EOSCore.Response.API
                 else
                     clean_core_liquid_balance = core_liquid_balance.Trim().Replace(" EOS", "");
 
-                return decimal.Parse(clean_core_liquid_balance);
+                return decimal.Parse(clean_core_liquid_balance, System.Globalization.CultureInfo.InvariantCulture);
             }
         }
         public Int64 ram_quota { get; set; }
@@ -104,7 +104,7 @@ namespace EOSNewYork.EOSCore.Response.API
                 else
                     net_weight_clean = net_weight.Trim().Replace(" EOS", "");
 
-                return decimal.Parse(net_weight_clean);
+                return decimal.Parse(net_weight_clean, System.Globalization.CultureInfo.InvariantCulture);
             }
         }
 
@@ -118,7 +118,7 @@ namespace EOSNewYork.EOSCore.Response.API
                 else
                     cpu_weight_clean = cpu_weight.Trim().Replace(" EOS", "");
 
-                return decimal.Parse(cpu_weight_clean);
+                return decimal.Parse(cpu_weight_clean, System.Globalization.CultureInfo.InvariantCulture);
             }
         }
     }
@@ -170,7 +170,7 @@ namespace EOSNewYork.EOSCore.Response.API
                 else
                     net_amount_clean = net_amount.Trim().Replace(" EOS", "");
 
-                return decimal.Parse(net_amount_clean);
+                return decimal.Parse(net_amount_clean, System.Globalization.CultureInfo.InvariantCulture);
             }
         }
 
@@ -184,7 +184,7 @@ namespace EOSNewYork.EOSCore.Response.API
                 else
                     cpu_amount_clean = cpu_amount.Trim().Replace(" EOS", "");
 
-                return decimal.Parse(cpu_amount_clean);
+                return decimal.Parse(cpu_amount_clean, System.Globalization.CultureInfo.InvariantCulture);
             }
         }
     }

--- a/EOSNewYork.EOSCore/Response/Table/ProducerRow.cs
+++ b/EOSNewYork.EOSCore/Response/Table/ProducerRow.cs
@@ -23,7 +23,7 @@ namespace EOSNewYork.EOSCore.Response.Table
         {
             get
             {
-                return double.Parse(total_votes);
+                return double.Parse(total_votes, System.Globalization.CultureInfo.InvariantCulture);
             }
         }
 

--- a/EOSNewYork.EOSCore/Response/Table/RammarketRow.cs
+++ b/EOSNewYork.EOSCore/Response/Table/RammarketRow.cs
@@ -19,7 +19,7 @@ namespace EOSNewYork.EOSCore.Response.Table
         {
             get
             {
-                return double.Parse(supply.Replace(" RAMCORE", ""));
+                return double.Parse(supply.Replace(" RAMCORE", ""), System.Globalization.CultureInfo.InvariantCulture);
             }
         }
 
@@ -45,7 +45,7 @@ namespace EOSNewYork.EOSCore.Response.Table
         {
             get
             {
-                return long.Parse(balance.Replace(" RAM",""));
+                return long.Parse(balance.Replace(" RAM",""), System.Globalization.CultureInfo.InvariantCulture);
             }
         }
     }
@@ -59,7 +59,7 @@ namespace EOSNewYork.EOSCore.Response.Table
         {
             get
             {
-                return double.Parse(balance.Replace(" EOS",""));
+                return double.Parse(balance.Replace(" EOS",""), System.Globalization.CultureInfo.InvariantCulture);
             }
         }
     }

--- a/EOSNewYork.EOSCore/Utilities/EOSUtility.cs
+++ b/EOSNewYork.EOSCore/Utilities/EOSUtility.cs
@@ -90,7 +90,7 @@ namespace EOSNewYork.EOSCore.Utilities
                 else
                     clean_core_liquid_balance = eosString.Trim().Replace(" EOS", "");
 
-                return decimal.Parse(clean_core_liquid_balance);
+                return decimal.Parse(clean_core_liquid_balance, System.Globalization.CultureInfo.InvariantCulture);
          
         }
 


### PR DESCRIPTION
Specify invariant culture for parsing decimals and doubles, because in some cultures the floating point delimiter is not a dot and for that cultures the parsing requires the culture specific delimiter. That would throw an exception if the exact culture is not specified. This problem does not occur when the current culture is en-XX.